### PR TITLE
Add basic i18n system with language detection

### DIFF
--- a/components/footer.html
+++ b/components/footer.html
@@ -1,6 +1,6 @@
 <footer>
-  <p>Logic in Philosophy © 2025 - <a href="mailto:contact@logicinphilosophy.com">contact@logicinphilosophy.com</a></p>
-  <ul class="social">
+  <p data-i18n="footer.copy">Logic in Philosophy © 2025 - <a href="mailto:contact@logicinphilosophy.com">contact@logicinphilosophy.com</a></p>
+  <ul class="social" data-i18n="footer.social">
     <li><a href="https://www.youtube.com" aria-label="YouTube">YouTube</a></li>
     <li><a href="https://github.com" aria-label="GitHub">GitHub</a></li>
   </ul>

--- a/components/header.html
+++ b/components/header.html
@@ -1,11 +1,11 @@
 <nav>
-  <a href="/" class="logo">Logic in Philosophy</a>
+  <a href="/" class="logo" data-i18n="logo">Logic in Philosophy</a>
   <ul class="navigation">
-    <li><a href="/">Home</a></li>
-    <li><a href="/articles/">Articles</a></li>
-    <li><a href="/events/">Events</a></li>
-    <li><a href="/broadcasts/">Broadcasts</a></li>
-    <li><a href="/contact/">Contact</a></li>
+    <li><a href="/" data-i18n="nav.home">Home</a></li>
+    <li><a href="/articles/" data-i18n="nav.articles">Articles</a></li>
+    <li><a href="/events/" data-i18n="nav.events">Events</a></li>
+    <li><a href="/broadcasts/" data-i18n="nav.broadcasts">Broadcasts</a></li>
+    <li><a href="/contact/" data-i18n="nav.contact">Contact</a></li>
   </ul>
   <ul class="languages">
     <li><a href="/en/">EN</a></li>

--- a/en/index.html
+++ b/en/index.html
@@ -6,18 +6,19 @@
     <title>Logic in Philosophy – Home</title>
     <link rel="stylesheet" href="/css/style.css">
     <script defer src="/js/inject.js"></script>
+    <script defer src="/js/i18n.js"></script>
 </head>
 <body>
     <header id="site-header"></header>
     <main>
         <section class="hero">
             <img src="/images/hero-placeholder.jpg" alt="">
-            <h1>Logic in Philosophy</h1>
+            <h1 data-i18n="home.title">Logic in Philosophy</h1>
         </section>
         <section class="cards">
-            <div class="card"><a href="/articles/">Articles</a></div>
-            <div class="card"><a href="/events/">Events</a></div>
-            <div class="card"><a href="/broadcasts/">Broadcasts</a></div>
+            <div class="card"><a href="/articles/" data-i18n="home.articles">Articles</a></div>
+            <div class="card"><a href="/events/" data-i18n="home.events">Events</a></div>
+            <div class="card"><a href="/broadcasts/" data-i18n="home.broadcasts">Broadcasts</a></div>
         </section>
     </main>
     <footer id="site-footer"></footer>

--- a/i18n/ar.json
+++ b/i18n/ar.json
@@ -1,0 +1,20 @@
+{
+  "logo": "المنطق في الفلسفة",
+  "nav": {
+    "home": "الرئيسية",
+    "articles": "مقالات",
+    "events": "فعاليات",
+    "broadcasts": "بثوث",
+    "contact": "اتصل بنا"
+  },
+  "home": {
+    "title": "المنطق في الفلسفة",
+    "articles": "مقالات",
+    "events": "فعاليات",
+    "broadcasts": "بثوث"
+  },
+  "footer": {
+    "copy": "المنطق في الفلسفة \u00a9 2025 - contact@logicinphilosophy.com",
+    "social": ["يوتيوب", "جيت هب"]
+  }
+}

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1,0 +1,20 @@
+{
+  "logo": "Logic in Philosophy",
+  "nav": {
+    "home": "Home",
+    "articles": "Articles",
+    "events": "Events",
+    "broadcasts": "Broadcasts",
+    "contact": "Contact"
+  },
+  "home": {
+    "title": "Logic in Philosophy",
+    "articles": "Articles",
+    "events": "Events",
+    "broadcasts": "Broadcasts"
+  },
+  "footer": {
+    "copy": "Logic in Philosophy \u00a9 2025 - contact@logicinphilosophy.com",
+    "social": ["YouTube", "GitHub"]
+  }
+}

--- a/i18n/he.json
+++ b/i18n/he.json
@@ -1,0 +1,20 @@
+{
+  "logo": "לוגיקה בפילוסופיה",
+  "nav": {
+    "home": "בית",
+    "articles": "מאמרים",
+    "events": "אירועים",
+    "broadcasts": "שידורים",
+    "contact": "צור קשר"
+  },
+  "home": {
+    "title": "לוגיקה בפילוסופיה",
+    "articles": "מאמרים",
+    "events": "אירועים",
+    "broadcasts": "שידורים"
+  },
+  "footer": {
+    "copy": "לוגיקה בפילוסופיה \u00a9 2025 - contact@logicinphilosophy.com",
+    "social": ["יוטיוב", "גיטהאב"]
+  }
+}

--- a/js/i18n.js
+++ b/js/i18n.js
@@ -1,0 +1,43 @@
+document.addEventListener('DOMContentLoaded', () => {
+  let lang = 'en';
+  if (location.pathname.startsWith('/he/')) {
+    lang = 'he';
+  } else if (location.pathname.startsWith('/ar/')) {
+    lang = 'ar';
+  }
+
+  fetch(`/i18n/${lang}.json`)
+    .then(res => res.json())
+    .then(messages => {
+      const applyTranslations = () => {
+        document.querySelectorAll('[data-i18n]').forEach(el => {
+          const key = el.getAttribute('data-i18n');
+          let value = messages;
+          key.split('.').forEach(part => {
+            if (value && part in value) {
+              value = value[part];
+            } else {
+              value = undefined;
+            }
+          });
+          if (value === undefined) return;
+
+          if ((el.tagName === 'UL' || el.tagName === 'OL') && Array.isArray(value)) {
+            el.innerHTML = value.map(item => `<li>${item}</li>`).join('');
+          } else {
+            el.textContent = value;
+          }
+        });
+      };
+
+      if (lang === 'he' || lang === 'ar') {
+        document.documentElement.setAttribute('dir', 'rtl');
+      } else {
+        document.documentElement.removeAttribute('dir');
+      }
+
+      applyTranslations();
+      document.addEventListener('componentsLoaded', applyTranslations);
+    })
+    .catch(err => console.error('Failed to load i18n file', err));
+});

--- a/js/inject.js
+++ b/js/inject.js
@@ -1,21 +1,29 @@
 document.addEventListener('DOMContentLoaded', () => {
   const header = document.getElementById('site-header');
+  const footer = document.getElementById('site-footer');
+  const promises = [];
+
   if (header) {
-    fetch('/components/header.html')
+    const p = fetch('/components/header.html')
       .then(response => response.text())
       .then(html => {
         header.innerHTML = html;
       })
       .catch(err => console.error('Failed to load header:', err));
+    promises.push(p);
   }
 
-  const footer = document.getElementById('site-footer');
   if (footer) {
-    fetch('/components/footer.html')
+    const p = fetch('/components/footer.html')
       .then(response => response.text())
       .then(html => {
         footer.innerHTML = html;
       })
       .catch(err => console.error('Failed to load footer:', err));
+    promises.push(p);
   }
+
+  Promise.all(promises).then(() => {
+    document.dispatchEvent(new CustomEvent('componentsLoaded'));
+  });
 });


### PR DESCRIPTION
## Summary
- detect page language and load translations
- inject rtl direction for Hebrew and Arabic
- update header, footer and index markup with `data-i18n` attributes
- load translations after header/footer components are injected
- provide sample translation JSON files

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_68601b49690c83289eb8ec32598b5d7c